### PR TITLE
Implement artifacts feature

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -220,6 +220,12 @@ please run the following command from your terminal:
 $ heroku run -a <app_name> "MIX_ENV=heroku mix ecto.migrate"
 ```
 
+### Limitations
+
+For the time being, you will not be able to use the artifact upload feature with Heroku,
+given that it does not provide permanent disk access. S3 support for artifact files is
+planned for the feature, certainly before 1.0 is released.
+
 ## Manual Installation
 
 The reason why we recommend Docker as the preferred installation method is because

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -5,6 +5,12 @@ services:
     command: foreground
     depends_on:
       - db
+    volumes:
+      # This will automatically create a volume on the host, and mount it at
+      # `/app/uploads`, which is where all artifacts will be stored. You can
+      # change the location of where the folder is created on the host with:
+      # - /opt/data:/app/uploads
+      - /app/uploads  
     ports:
       # The first entry is the exposed port, the second is where the exposed
       # port should bind to. Use the same second value here as PORT below

--- a/lib/alloy_ci/builds/artifact.ex
+++ b/lib/alloy_ci/builds/artifact.ex
@@ -1,0 +1,27 @@
+defmodule AlloyCi.Artifact do
+  @moduledoc """
+  A Build represents a single job unit for a Pipeline. Each job defined in
+  the `.alloy-ci.json` file will be stored as a Build.
+  """
+  use AlloyCi.Web, :schema
+  use Arc.Ecto.Schema
+
+  schema "artifacts" do
+    field(:file, AlloyCi.Artifacts.Type)
+    field(:expires_at, :naive_datetime)
+
+    belongs_to(:build, AlloyCi.Build)
+
+    timestamps()
+  end
+
+  @required_fields ~w(build_id)a
+  @optional_fields ~w(expires_at)a
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required_fields ++ @optional_fields)
+    |> cast_attachments(params, [:file])
+    |> validate_required(@required_fields)
+  end
+end

--- a/lib/alloy_ci/builds/artifacts.ex
+++ b/lib/alloy_ci/builds/artifacts.ex
@@ -1,0 +1,11 @@
+defmodule AlloyCi.Artifacts do
+  @moduledoc """
+  Intermediate module for Arc and the Build Artifacts
+  """
+  use Arc.Definition
+  use Arc.Ecto.Definition
+
+  def storage_dir(_, {_file, artifact}) do
+    "uploads/artifacts/#{artifact.id}"
+  end
+end

--- a/lib/alloy_ci/builds/build.ex
+++ b/lib/alloy_ci/builds/build.ex
@@ -7,7 +7,9 @@ defmodule AlloyCi.Build do
 
   schema "builds" do
     field(:allow_failure, :boolean, default: false)
+    field(:artifacts, :map)
     field(:commands, {:array, :string})
+    field(:deps, {:array, :string})
     field(:finished_at, :naive_datetime)
     field(:name, :string)
     field(:options, :map)
@@ -26,11 +28,13 @@ defmodule AlloyCi.Build do
     belongs_to(:project, AlloyCi.Project)
     belongs_to(:runner, AlloyCi.Runner)
 
+    has_one(:artifact, AlloyCi.Artifact)
+
     timestamps()
   end
 
   @required_fields ~w(commands name options pipeline_id project_id token)a
-  @optional_fields ~w(allow_failure finished_at queued_at runner_id stage
+  @optional_fields ~w(allow_failure artifacts deps finished_at queued_at runner_id stage
                       started_at status tags trace variables when stage_idx)a
 
   def changeset(struct, params \\ %{}) do

--- a/lib/alloy_ci/lib/fake_storage.ex
+++ b/lib/alloy_ci/lib/fake_storage.ex
@@ -5,7 +5,7 @@ defmodule Arc.Storage.Fake do
   end
 
   def url(_definition, _version, {file, _scope}, _options \\ []) do
-    "test/fixtures/#{file}" |> URI.encode()
+    "/test/fixtures/#{file[:file_name]}" |> URI.encode()
   end
 
   def delete(_definition, _version, _file_and_scope) do

--- a/lib/alloy_ci/projects/projects.ex
+++ b/lib/alloy_ci/projects/projects.ex
@@ -42,6 +42,8 @@ defmodule AlloyCi.Projects do
     end
   end
 
+  def can_manage?(nil, _), do: false
+
   def can_manage?(id, user) do
     permission = get_project_permission(id, user)
 

--- a/lib/alloy_ci/web/controllers/api/builds_artifact_controller.ex
+++ b/lib/alloy_ci/web/controllers/api/builds_artifact_controller.ex
@@ -1,0 +1,65 @@
+defmodule AlloyCi.Web.Api.BuildsArtifactController do
+  use AlloyCi.Web, :controller
+  alias AlloyCi.{Artifacts, Builds, Runners}
+
+  def authorize(conn, params, _, _) do
+    case Runners.get_by(token: params["token"]) do
+      nil ->
+        conn
+        |> put_status(403)
+        |> json(%{message: "403 Forbidden"})
+
+      _ ->
+        conn
+        |> put_status(200)
+        |> json(%{message: "200 Credentials are valid"})
+    end
+  end
+
+  def create(conn, %{"id" => id, "file" => file, "expire_in" => expiry}, _, _) do
+    [token] = get_req_header(conn, "job-token")
+
+    with {:ok, %{artifacts: %{}} = build} <- Builds.get_by(id, token),
+         {:ok, _} <- Builds.store_artifact(build, file, expiry) do
+      conn
+      |> put_status(201)
+      |> json(%{message: "201 OK"})
+    else
+      {:error, nil} ->
+        conn
+        |> put_status(403)
+        |> json(%{error: "403 Forbidden"})
+
+      {:ok, _} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "404 Not Found"})
+    end
+  end
+
+  def show(conn, %{"id" => id}, _, _) do
+    [token] = get_req_header(conn, "job-token")
+
+    with {:ok, %{artifacts: %{}} = build} <- Builds.get_with_artifact(id, token),
+         file <- Artifacts.url({build.artifact.file, build.artifact}, signed: true) do
+      conn
+      |> put_resp_content_type("application/octet-stream", "utf-8")
+      |> put_resp_header("content-transfer-encoding", "binary")
+      |> put_resp_header(
+        "content-disposition",
+        "attachment; filename=#{build.artifact.file[:file_name]}"
+      )
+      |> send_file(200, "./#{file}")
+    else
+      {:error, nil} ->
+        conn
+        |> put_status(403)
+        |> json(%{error: "403 Forbidden"})
+
+      {:ok, _} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "404 Not Found"})
+    end
+  end
+end

--- a/lib/alloy_ci/web/endpoint.ex
+++ b/lib/alloy_ci/web/endpoint.ex
@@ -28,6 +28,7 @@ defmodule AlloyCi.Web.Endpoint do
 
   plug(
     Plug.Parsers,
+    length: 100_000_000,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
     json_decoder: Poison

--- a/lib/alloy_ci/web/router.ex
+++ b/lib/alloy_ci/web/router.ex
@@ -124,6 +124,9 @@ defmodule AlloyCi.Web.Router do
     scope "/jobs" do
       post("/request", BuildsEventController, :request, as: :verify)
       put("/:id", BuildsEventController, :update)
+      post("/:id/artifacts/authorize", BuildsArtifactController, :authorize)
+      post("/:id/artifacts", BuildsArtifactController, :create)
+      get("/:id/artifacts", BuildsArtifactController, :show)
       patch("/:id/trace", BuildsEventController, :trace)
       # add routes for artifacts here
     end

--- a/lib/alloy_ci/web/views/api/builds_event_view.ex
+++ b/lib/alloy_ci/web/views/api/builds_event_view.ex
@@ -27,10 +27,10 @@ defmodule AlloyCi.Web.Api.BuildsEventView do
       steps: build.steps,
       image: build.image,
       services: build.services,
-      # artifacts: [], # Implement artifacts in version 1.0
-      cache: [build.options["cache"]] || []
-      # credentials: [],
-      # dependencies: [] # Implement artifacts in version 1.0
+      artifacts: [build.artifacts] || [],
+      cache: [build.options["cache"]] || [],
+      dependencies: build.dependencies
+      # credentials: []
     }
   end
 

--- a/priv/repo/migrations/20180215221951_create_artifact.exs
+++ b/priv/repo/migrations/20180215221951_create_artifact.exs
@@ -1,0 +1,13 @@
+defmodule AlloyCi.Repo.Migrations.CreateArtifact do
+  use Ecto.Migration
+
+  def change do
+    create table(:artifacts) do
+      add(:build_id, references(:builds, on_delete: :delete_all, null: false))
+      add(:file, :string)
+      add(:expires_at, :naive_datetime)
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20180221221425_add_artifacts_and_deps_to_build.exs
+++ b/priv/repo/migrations/20180221221425_add_artifacts_and_deps_to_build.exs
@@ -1,0 +1,11 @@
+defmodule AlloyCi.Repo.Migrations.AddArtifactsAndDepsToBuild do
+  use Ecto.Migration
+
+  def change do
+    alter table(:builds) do
+      add(:artifacts, :map)
+      add(:artifact_id, references(:artifacts))
+      add(:deps, {:array, :string})
+    end
+  end
+end

--- a/test/fixtures/full_features_config.json
+++ b/test/fixtures/full_features_config.json
@@ -1,13 +1,22 @@
 {
+  "stages": [
+    "test",
+    "compile",
+    "deploy"
+  ],
   "image": {
     "name": "elixir:latest",
-    "entrypoint": ["/bin/bash"]
+    "entrypoint": [
+      "/bin/bash"
+    ]
   },
   "services": [
     {
       "name": "postgres:latest",
       "alias": "postgres-1",
-      "command": ["/bin/sh"]
+      "command": [
+        "/bin/sh"
+      ]
     }
   ],
   "cache": {
@@ -34,9 +43,14 @@
   ],
   "mix": {
     "image": "elixir:1.5",
-    "services": ["postgres:9.6"],
+    "services": [
+      "postgres:9.6"
+    ],
     "stage": "test",
-    "tags": ["elixir", "postgres"],
+    "tags": [
+      "elixir",
+      "postgres"
+    ],
     "script": [
       "mix test"
     ]
@@ -47,9 +61,30 @@
       "redis:latest"
     ],
     "stage": "test",
-    "tags": ["elixir"],
+    "tags": [
+      "elixir"
+    ],
     "script": [
       "mix credo"
     ]
+  },
+  "distillery": {
+    "stage": "compile",
+    "tags": [
+      "elixir",
+      "postgres"
+    ],
+    "variables": {
+      "MIX_ENV": "prod"
+    },
+    "script": [
+      "mix docker.build --tag latest"
+    ],
+    "artifacts": {
+      "paths": [
+        "alloy_ci.tar.gz",
+        "_build/prod/lib/alloy_ci"
+      ]
+    }
   }
 }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -3,8 +3,15 @@ defmodule AlloyCi.Factory do
   """
   use ExMachina.Ecto, repo: AlloyCi.Repo
 
-  alias AlloyCi.{Authentication, Build, GuardianToken, Installation, Pipeline}
+  alias AlloyCi.{Artifact, Authentication, Build, GuardianToken, Installation, Pipeline}
   alias AlloyCi.{Project, ProjectPermission, Runner, User}
+
+  def artifact_factory do
+    %Artifact{
+      build: build(:build),
+      expires_at: Timex.now() |> Timex.shift(days: 7)
+    }
+  end
 
   def authentication_factory do
     %Authentication{
@@ -17,7 +24,7 @@ defmodule AlloyCi.Factory do
 
   def build_factory do
     %Build{
-      name: "build-1",
+      name: sequence("build-name"),
       commands: ["echo hello", "iex -S"],
       options: %{"variables" => %{"GITHUB" => "yes"}},
       status: "pending",
@@ -45,6 +52,7 @@ defmodule AlloyCi.Factory do
     pipeline = insert(:pipeline)
 
     %Build{
+      artifacts: %{"paths" => ["alloy_ci.tar.gz", "_build/prod/lib/alloy_ci"]},
       name: "full-build-1",
       commands: ["mix test"],
       options: %{

--- a/test/web/controllers/api/builds_artifact_controller_test.exs
+++ b/test/web/controllers/api/builds_artifact_controller_test.exs
@@ -1,0 +1,119 @@
+defmodule AlloyCi.Web.Api.BuildsArtifactControllerTest do
+  @moduledoc """
+  """
+  use AlloyCi.Web.ConnCase
+  alias AlloyCi.{Artifact, Builds}
+  import AlloyCi.Factory
+
+  setup do
+    runner = insert(:runner)
+
+    params = %{
+      info: %{
+        name: "runner",
+        version: "1.0",
+        platform: "darwin",
+        architecture: "amd64"
+      }
+    }
+
+    {:ok, %{runner: runner, params: params}}
+  end
+
+  describe "create/4" do
+    test "it creates a new artifact" do
+      build = insert(:extended_build, status: "running")
+
+      params = %{
+        file: %Plug.Upload{
+          path: "test/fixtures/broken_config.json",
+          filename: "broken_config.json"
+        },
+        expire_in: "7d"
+      }
+
+      conn =
+        build_conn()
+        |> put_req_header("job-token", build.token)
+        |> post("/api/v4/jobs/#{build.id}/artifacts", params)
+
+      {:ok, build} = Builds.get_with_artifact(build.id, build.token)
+
+      assert conn.status == 201
+      assert build.artifact != nil
+      assert build.artifact.file[:file_name] == "broken_config.json"
+    end
+
+    test "returns 403 when wrong token" do
+      build = insert(:extended_build, status: "running")
+
+      conn =
+        build_conn()
+        |> put_req_header("job-token", "token-1")
+        |> post("/api/v4/jobs/#{build.id}/artifacts", %{file: "", expire_in: ""})
+
+      assert conn.status == 403
+      assert conn.resp_body =~ "Forbidden"
+    end
+
+    test "returns 404 when build does not declare artifacts" do
+      build = insert(:full_build, status: "running")
+
+      conn =
+        build_conn()
+        |> put_req_header("job-token", build.token)
+        |> post("/api/v4/jobs/#{build.id}/artifacts", %{file: "", expire_in: ""})
+
+      assert conn.status == 404
+      assert conn.resp_body =~ "Not Found"
+    end
+  end
+
+  describe "show/4" do
+    test "it downloads the correct artifact" do
+      build = insert(:extended_build, status: "success")
+
+      insert(:artifact, build: build)
+      |> Artifact.changeset(%{
+        file: %Plug.Upload{
+          path: "test/fixtures/broken_config.json",
+          filename: "broken_config.json"
+        }
+      })
+      |> Repo.update()
+
+      conn =
+        build_conn()
+        |> put_req_header("job-token", build.token)
+        |> get("/api/v4/jobs/#{build.id}/artifacts")
+
+      assert conn.status == 200
+      assert conn.state == :file
+      assert conn.resp_body == File.read!("test/fixtures/broken_config.json")
+    end
+
+    test "returns 403 when wrong token" do
+      build = insert(:extended_build, status: "running")
+
+      conn =
+        build_conn()
+        |> put_req_header("job-token", "token-1")
+        |> get("/api/v4/jobs/#{build.id}/artifacts")
+
+      assert conn.status == 403
+      assert conn.resp_body =~ "Forbidden"
+    end
+
+    test "returns 404 when build does not declare artifacts" do
+      build = insert(:full_build, status: "running")
+
+      conn =
+        build_conn()
+        |> put_req_header("job-token", build.token)
+        |> get("/api/v4/jobs/#{build.id}/artifacts")
+
+      assert conn.status == 404
+      assert conn.resp_body =~ "Not Found"
+    end
+  end
+end

--- a/test/workers/process_pipeline_worker_test.exs
+++ b/test/workers/process_pipeline_worker_test.exs
@@ -44,6 +44,7 @@ defmodule AlloyCi.ProcessPipelineWorkerTest do
 
     assert build1.status == "success"
     assert build2.status == "pending"
+    assert build2.queued_at != nil
     assert pipeline.status == "running"
 
     Builds.transition_status(build2, "success")
@@ -94,11 +95,154 @@ defmodule AlloyCi.ProcessPipelineWorkerTest do
     assert build3.status == "pending"
     assert pipeline.status == "running"
 
+    build3 = Builds.transition_status(build3, "success")
+    assert build3.finished_at != nil
+    ProcessPipelineWorker.perform(pipeline.id)
+    pipeline = Pipeline |> Repo.get(pipeline.id)
+
+    assert pipeline.status == "failed"
+  end
+
+  test "it processes the pipeline and updates the second stage on success", %{
+    pipeline: pipeline,
+    project: project
+  } do
+    insert(
+      :build,
+      pipeline_id: pipeline.id,
+      stage_idx: 0,
+      project_id: project.id,
+      status: "success"
+    )
+
+    build2 =
+      insert(
+        :build,
+        pipeline_id: pipeline.id,
+        stage_idx: 0,
+        project_id: project.id,
+        status: "success"
+      )
+
+    build3 =
+      insert(
+        :build,
+        pipeline_id: pipeline.id,
+        stage_idx: 1,
+        project_id: project.id,
+        status: "created"
+      )
+
+    ProcessPipelineWorker.perform(pipeline.id)
+
+    build2 = Builds.get(build2.id)
+    build3 = Builds.get(build3.id)
+    pipeline = Pipeline |> Repo.get(pipeline.id)
+
+    assert build2.status == "success"
+    assert build3.status == "pending"
+    assert pipeline.status == "running"
+
+    Builds.transition_status(build3, "success")
+    ProcessPipelineWorker.perform(pipeline.id)
+    pipeline = Pipeline |> Repo.get(pipeline.id)
+
+    assert pipeline.status == "success"
+  end
+
+  test "it doesn't processes the pipeline and updates the second stage on failure", %{
+    pipeline: pipeline,
+    project: project
+  } do
+    insert(
+      :build,
+      pipeline_id: pipeline.id,
+      stage_idx: 0,
+      project_id: project.id,
+      status: "success"
+    )
+
+    build2 =
+      insert(
+        :build,
+        pipeline_id: pipeline.id,
+        stage_idx: 0,
+        project_id: project.id,
+        status: "failed"
+      )
+
+    build3 =
+      insert(
+        :build,
+        pipeline_id: pipeline.id,
+        stage_idx: 1,
+        project_id: project.id,
+        status: "created"
+      )
+
+    ProcessPipelineWorker.perform(pipeline.id)
+
+    build2 = Builds.get(build2.id)
+    build3 = Builds.get(build3.id)
+    pipeline = Pipeline |> Repo.get(pipeline.id)
+
+    assert build2.status == "failed"
+    assert build3.status == "created"
+    assert pipeline.status == "failed"
+
     Builds.transition_status(build3, "success")
     ProcessPipelineWorker.perform(pipeline.id)
     pipeline = Pipeline |> Repo.get(pipeline.id)
 
     assert pipeline.status == "failed"
+  end
+
+  test "it processes the pipeline and updates the second stage on success or allowed failures", %{
+    pipeline: pipeline,
+    project: project
+  } do
+    insert(
+      :build,
+      pipeline_id: pipeline.id,
+      stage_idx: 0,
+      project_id: project.id,
+      status: "success"
+    )
+
+    build2 =
+      insert(
+        :build,
+        pipeline_id: pipeline.id,
+        stage_idx: 0,
+        project_id: project.id,
+        status: "failed",
+        allow_failure: true
+      )
+
+    build3 =
+      insert(
+        :build,
+        pipeline_id: pipeline.id,
+        stage_idx: 1,
+        project_id: project.id,
+        status: "created"
+      )
+
+    ProcessPipelineWorker.perform(pipeline.id)
+
+    build2 = Builds.get(build2.id)
+    build3 = Builds.get(build3.id)
+    pipeline = Pipeline |> Repo.get(pipeline.id)
+
+    assert build2.status == "failed"
+    assert build3.status == "pending"
+    assert pipeline.status == "running"
+
+    Builds.transition_status(build3, "success")
+    ProcessPipelineWorker.perform(pipeline.id)
+    pipeline = Pipeline |> Repo.get(pipeline.id)
+
+    assert pipeline.status == "success"
   end
 
   test "it processes the pipeline and updates the builds on success", %{


### PR DESCRIPTION
This PR implements the backend portion of the artifacts feature.

Runners can now:
- Upload artifacts
- Download artifacts
- Make use of dependent builds/artifacts

`.alloy-ci.json` file can now:
- Define the artifacts section, to declare paths, expire times, etc.
- Define specific dependent builds

Closes #3 
Connect #2 