### PR TITLE
Add support for manual builds

### DIFF
--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -67,6 +67,7 @@
         # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
         #
         {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+        {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 12},
 
         # You can also customize the exit_status of each check.
         # If you don't want TODO comments to cause `mix credo` to fail, just

--- a/lib/alloy_ci/web/router.ex
+++ b/lib/alloy_ci/web/router.ex
@@ -69,7 +69,7 @@ defmodule AlloyCi.Web.Router do
     resources "/projects", ProjectController do
       resources("/pipelines", PipelineController, only: [:create, :delete, :show])
 
-      resources("/builds", BuildController, only: [:show, :create]) do
+      resources("/builds", BuildController, only: [:show, :create, :update]) do
         get("/artifact", BuildController, :artifact, as: :artifact)
         post("/artifact/keep", BuildController, :keep_artifact, as: :keep_artifact)
       end

--- a/lib/alloy_ci/web/templates/build/show.html.eex
+++ b/lib/alloy_ci/web/templates/build/show.html.eex
@@ -12,6 +12,8 @@
         <p><span class="text-muted">Duration: </span><%= icon("clock-o") %> <%= build_duration(@build) %></p>
         <p><span class="text-muted">Triggered: </span><%= from_now(@build.inserted_at) %></p>
         <p><span class="text-muted">Runner: </span><%= runner(@build.runner_id) %></p>
+        <p><span class="text-muted">Start condition: </span><%= @build.when %></p>
+        <p><span class="text-muted">Allowed to fail: </span><%= boolean_to_icon(@build.allow_failure) %></p>
         <span class="text-muted">Tags: </span><%= tags(@build.tags) %>
         
         <hr>

--- a/lib/alloy_ci/web/templates/pipeline/build.html.eex
+++ b/lib/alloy_ci/web/templates/pipeline/build.html.eex
@@ -13,7 +13,7 @@
         <span data-toggle="tooltip" 
               data-placement="bottom"
               title="Status: <%= String.capitalize(@build.status) %>">
-          <%= build_status_icon(@build.status) %>
+          <%= status_icon(@build.status, "fa-lg") %>
         </span>
         <%= build_actions(@conn, @build, "fa-lg") %>
       </div>

--- a/lib/alloy_ci/web/views/build_view.ex
+++ b/lib/alloy_ci/web/views/build_view.ex
@@ -21,13 +21,24 @@ defmodule AlloyCi.Web.BuildView do
   end
 
   def artifact_for(_, _) do
-    content_tag :p do
-      "No artifacts were generated for this build."
-    end
+    content_tag(:p, "No artifacts were generated for this build.")
   end
 
   def build_actions(conn, build, icon_class \\ "")
   def build_actions(_, %{status: s}, _) when s in ~w(pending running created), do: ""
+
+  def build_actions(conn, %{status: "manual", when: "manual"} = build, icon_class) do
+    content_tag :span,
+      class: "float-right",
+      data: [toggle: "tooltip", placement: "bottom"],
+      title: "Perform this build!" do
+      link to: project_build_path(conn, :update, build.project_id, build.id),
+           method: :put,
+           class: "action-link" do
+        icon("play", icon_class)
+      end
+    end
+  end
 
   def build_actions(conn, build, icon_class) do
     content_tag :span,
@@ -54,18 +65,8 @@ defmodule AlloyCi.Web.BuildView do
   def build_loading_icon("running"), do: icon("spinner", "fa-spin fa-2x")
   def build_loading_icon(_), do: ""
 
-  def build_status_icon("created"), do: icon("calendar", "fa-lg")
-  def build_status_icon("failed"), do: icon("close", "fa-lg")
-  def build_status_icon("pending"), do: icon("circle-o-notch", "fa-lg")
-  def build_status_icon("running"), do: icon("circle-o-notch", "fa-spin fa-lg")
-  def build_status_icon("success"), do: icon("check", "fa-lg")
-  def build_status_icon(_), do: icon("ban")
-
   def from_now(nil), do: "Never"
-
-  def from_now(time) do
-    time |> Timex.from_now()
-  end
+  def from_now(time), do: time |> Timex.from_now()
 
   def runner(nil), do: "Pending"
   def runner(id), do: "##{id}"

--- a/lib/alloy_ci/web/views/helpers.ex
+++ b/lib/alloy_ci/web/views/helpers.ex
@@ -7,6 +7,9 @@ defmodule AlloyCi.Web.ViewHelpers do
 
   @github_api Application.get_env(:alloy_ci, :github_api)
 
+  def boolean_to_icon(true), do: icon("check")
+  def boolean_to_icon(false), do: icon("close")
+
   def callout("success"), do: "callout-success"
   def callout("failed"), do: "callout-danger"
   def callout("running"), do: "callout-warning"
@@ -113,12 +116,14 @@ defmodule AlloyCi.Web.ViewHelpers do
   def status_btn("running"), do: "btn-warning"
   def status_btn(_), do: "btn-outline-secondary active"
 
-  def status_icon("created"), do: icon("calendar")
-  def status_icon("failed"), do: icon("close")
-  def status_icon("pending"), do: icon("circle-o-notch")
-  def status_icon("running"), do: icon("circle-o-notch", "fa-spin")
-  def status_icon("success"), do: icon("check")
-  def status_icon(_), do: icon("ban")
+  def status_icon(status, class \\ "")
+  def status_icon("created", class), do: icon("calendar", class)
+  def status_icon("failed", class), do: icon("close", class)
+  def status_icon("manual", class), do: icon("hand-paper-o", class)
+  def status_icon("pending", class), do: icon("circle-o-notch", class)
+  def status_icon("running", class), do: icon("circle-o-notch", "fa-spin #{class}")
+  def status_icon("success", class), do: icon("check", class)
+  def status_icon(_, _), do: icon("ban")
 
   defp status_class(:info), do: "primary"
   defp status_class(:error), do: "danger"

--- a/lib/alloy_ci/web/views/pipeline_view.ex
+++ b/lib/alloy_ci/web/views/pipeline_view.ex
@@ -1,7 +1,7 @@
 defmodule AlloyCi.Web.PipelineView do
   use AlloyCi.Web, :view
   alias AlloyCi.Projects
-  import AlloyCi.Web.BuildView, only: [build_actions: 3, build_duration: 1, build_status_icon: 1]
+  import AlloyCi.Web.BuildView, only: [build_actions: 3, build_duration: 1]
 
   def can_manage?(pipeline, user) do
     Projects.can_manage?(pipeline.project_id, user)

--- a/test/builds/builds_test.exs
+++ b/test/builds/builds_test.exs
@@ -36,7 +36,8 @@ defmodule AlloyCi.BuildsTest do
                      project_id: build.project_id,
                      status: build.status,
                      finished_at: nil,
-                     started_at: nil
+                     started_at: nil,
+                     when: "on_success"
                    }
                  ]
                }
@@ -80,7 +81,9 @@ defmodule AlloyCi.BuildsTest do
              ]
 
       assert build.project_id == pipeline.project_id
-      assert build.when == "on_success"
+      assert build.when == "manual"
+      assert build.allow_failure == true
+      assert build.status == "created"
       assert build.tags == project.tags
       assert build.stage_idx == 1
       assert build.stage == "test"

--- a/test/fixtures/rails_config.yml
+++ b/test/fixtures/rails_config.yml
@@ -1,5 +1,6 @@
 ---
 Rspec Tests:
+  when: manual
   script:
   - bundle install --path vendor/bundle
   - bundle exec rake db:setup

--- a/test/pipelines/pipelines_test.exs
+++ b/test/pipelines/pipelines_test.exs
@@ -41,9 +41,12 @@ defmodule AlloyCi.PipelinesTest do
   end
 
   describe "cancel/1" do
-    test "it cancels the pipeline", %{pipeline: pipeline} do
+    test "it cancels the pipeline and its builds", %{pipeline: pipeline} do
+      build = insert(:build, pipeline: pipeline, project: pipeline.project)
       assert {:ok, pipeline} = Pipelines.cancel(pipeline)
       assert pipeline.status == "cancelled"
+      build = Builds.get(build.id)
+      assert build.status == "cancelled"
     end
   end
 


### PR DESCRIPTION
Includes changes to UI, pipeline worker, build creation, and build enqueuing.

Manual builds can now be started via the Pipeline view. If marked as blocking (`allow_failure: false`) they will stop the rest of the pipeline from continuing until this build has been executed successfully.

Closes #20